### PR TITLE
Add Orleans API layer

### DIFF
--- a/Gomoku.sln
+++ b/Gomoku.sln
@@ -10,6 +10,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gomoku.Domain.Tests", "src/
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gomoku.Application.Tests", "src/Gomoku.Application.Tests/Gomoku.Application.Tests.csproj", "{44444444-4444-4444-4444-444444444444}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gomoku.Api", "src/Gomoku.Api/Gomoku.Api.csproj", "{55555555-5555-5555-5555-555555555555}"
+EndProject
 Global
     GlobalSection(SolutionConfigurationPlatforms) = preSolution
         Debug|Any CPU = Debug|Any CPU
@@ -32,6 +34,10 @@ Global
         {44444444-4444-4444-4444-444444444444}.Debug|Any CPU.Build.0 = Debug|Any CPU
         {44444444-4444-4444-4444-444444444444}.Release|Any CPU.ActiveCfg = Release|Any CPU
         {44444444-4444-4444-4444-444444444444}.Release|Any CPU.Build.0 = Release|Any CPU
+        {55555555-5555-5555-5555-555555555555}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {55555555-5555-5555-5555-555555555555}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {55555555-5555-5555-5555-555555555555}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {55555555-5555-5555-5555-555555555555}.Release|Any CPU.Build.0 = Release|Any CPU
     EndGlobalSection
 EndGlobal
 

--- a/src/Gomoku.Api/GameGrain.cs
+++ b/src/Gomoku.Api/GameGrain.cs
@@ -1,0 +1,36 @@
+using Gomoku.Application;
+using Gomoku.Domain;
+using Orleans;
+
+public class GameGrain : Grain, IGameGrain
+{
+    private GameAggregate? _game;
+
+    public Task<GameId> StartGame(StartGameCommand command)
+    {
+        _game = new GameAggregate(new GameId(this.GetPrimaryKey()), command.BlackPlayer, command.WhitePlayer, command.BoardSize);
+        return Task.FromResult(_game.Id);
+    }
+
+    public Task<bool> PlaceStone(PlaceStoneCommand command)
+    {
+        if (_game is null || _game.Id != command.GameId)
+        {
+            return Task.FromResult(false);
+        }
+
+        var result = _game.PlaceStone(command.Coordinate);
+        return Task.FromResult(result);
+    }
+
+    public Task<GameStatusDto?> GetGameStatus()
+    {
+        if (_game is null)
+        {
+            return Task.FromResult<GameStatusDto?>(null);
+        }
+
+        var dto = new GameStatusDto(_game.Board, _game.CurrentPlayer, _game.Winner);
+        return Task.FromResult<GameStatusDto?>(dto);
+    }
+}

--- a/src/Gomoku.Api/Gomoku.Api.csproj
+++ b/src/Gomoku.Api/Gomoku.Api.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Gomoku.Application/Gomoku.Application.csproj" />
+    <ProjectReference Include="../Gomoku.Domain/Gomoku.Domain.csproj" />
+    <PackageReference Include="Microsoft.Orleans.Server" Version="7.2.0" />
+  </ItemGroup>
+</Project>

--- a/src/Gomoku.Api/IGameGrain.cs
+++ b/src/Gomoku.Api/IGameGrain.cs
@@ -1,0 +1,10 @@
+using Gomoku.Application;
+using Gomoku.Domain;
+using Orleans;
+
+public interface IGameGrain : IGrainWithGuidKey
+{
+    Task<GameId> StartGame(StartGameCommand command);
+    Task<bool> PlaceStone(PlaceStoneCommand command);
+    Task<GameStatusDto?> GetGameStatus();
+}

--- a/src/Gomoku.Api/Program.cs
+++ b/src/Gomoku.Api/Program.cs
@@ -1,0 +1,40 @@
+using Gomoku.Application;
+using Gomoku.Domain;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Orleans;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Host.UseOrleans(silo =>
+{
+    silo.UseLocalhostClustering();
+});
+
+var app = builder.Build();
+
+app.MapPost("/games", async (IGrainFactory grains, StartGameCommand command) =>
+{
+    var id = Guid.NewGuid();
+    var grain = grains.GetGrain<IGameGrain>(id);
+    var gameId = await grain.StartGame(command);
+    return Results.Ok(gameId);
+});
+
+app.MapPost("/games/{id:guid}/stones", async (IGrainFactory grains, Guid id, Coordinate coordinate) =>
+{
+    var grain = grains.GetGrain<IGameGrain>(id);
+    var placed = await grain.PlaceStone(new PlaceStoneCommand(new GameId(id), coordinate));
+    return Results.Ok(placed);
+});
+
+app.MapGet("/games/{id:guid}", async (IGrainFactory grains, Guid id) =>
+{
+    var grain = grains.GetGrain<IGameGrain>(id);
+    var status = await grain.GetGameStatus();
+    return status is not null ? Results.Ok(status) : Results.NotFound();
+});
+
+app.Run();
+


### PR DESCRIPTION
## Summary
- add `Gomoku.Api` ASP.NET Core project hosting an Orleans silo
- implement `IGameGrain` and `GameGrain`
- expose endpoints to create games, place stones and query status
- include project in solution

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848dda1d930833189f82632f5dfe178